### PR TITLE
fix: bump deepmerge dependency fixing optimistic updates

### DIFF
--- a/packages/normy/package.json
+++ b/packages/normy/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
-    "deepmerge": "4.0.0"
+    "deepmerge": "4.3.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bump to use the latest deepmerge, I have kept this pinned to latest rather than using `^` as this was the existing convention.

Specifically, this will resolve an issue I experienced with optimistic updates of objects with falsey values fixed in 4.2.1, see
https://github.com/TehShrike/deepmerge/pull/172