### PR TITLE
add normalize meta property

### DIFF
--- a/packages/normy-react-query/src/index.ts
+++ b/packages/normy-react-query/src/index.ts
@@ -5,3 +5,14 @@ export {
   QueryNormalizerProvider,
   useQueryNormalizer,
 } from './QueryNormalizerProvider';
+
+interface NormyReactQueryMeta extends Record<string, unknown> {
+  normalize?: boolean;
+}
+
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryMeta: NormyReactQueryMeta;
+    mutationMeta: NormyReactQueryMeta;
+  }
+}


### PR DESCRIPTION
Adds extended React Query meta property to **@normy/react-query** ( Issue #26 )

Not sure of build & testing process for this repo so let me know, but running `pnpm build` and using the **@normy/react-query** package locally in the react-query example had the `meta` type set correctly.

