### PR TITLE
Expose getting query keys by normalized ID

### DIFF
--- a/packages/normy-react-query/src/create-query-normalizer.ts
+++ b/packages/normy-react-query/src/create-query-normalizer.ts
@@ -1,9 +1,9 @@
-import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import {
   createNormalizer,
-  type NormalizerConfig,
   type Data,
+  type NormalizerConfig,
 } from '@normy/core';
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
 
 const shouldBeNormalized = (
   globalNormalize: boolean,
@@ -114,5 +114,6 @@ export const createQueryNormalizer = (
     },
     getObjectById: normalizer.getObjectById,
     getQueryFragment: normalizer.getQueryFragment,
+    getQueriesById: normalizer.getQueriesById,
   };
 };

--- a/packages/normy-react-query/src/create-query-normalizer.ts
+++ b/packages/normy-react-query/src/create-query-normalizer.ts
@@ -5,6 +5,10 @@ import {
 } from '@normy/core';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
 
+const cleanIds = (ids: string | string[]) => {
+  return Array.isArray(ids) ? ids.map(id => `@@${id}`) : `@@${ids}`;
+};
+
 const shouldBeNormalized = (
   globalNormalize: boolean,
   localNormalize: boolean | undefined,
@@ -114,6 +118,16 @@ export const createQueryNormalizer = (
     },
     getObjectById: normalizer.getObjectById,
     getQueryFragment: normalizer.getQueryFragment,
-    getQueriesById: normalizer.getQueriesById,
+    getQueryKeysById: (ids: string | string[]) => {
+      return normalizer
+        .getQueriesById(cleanIds(ids))
+        .map(key => JSON.parse(key));
+    },
+    invalidateQueriesById: (ids: string | string[]) => {
+      normalizer
+        .getQueriesById(cleanIds(ids))
+        .map(key => JSON.parse(key))
+        .forEach(query => queryClient.invalidateQueries({ queryKey: query }));
+    },
   };
 };

--- a/packages/normy/src/create-normalizer.ts
+++ b/packages/normy/src/create-normalizer.ts
@@ -151,10 +151,14 @@ export const createNormalizer = (
     return differentObjects;
   };
 
-  const getQueriesById = (mutationDependencies: ReadonlyArray<string>) =>
+  const getQueriesById = (
+    mutationDependencies: ReadonlyArray<string> | Readonly<string>,
+  ) =>
     getQueriesDependentOnMutation(
       normalizedData.dependentQueries,
-      mutationDependencies,
+      Array.isArray(mutationDependencies)
+        ? mutationDependencies
+        : [mutationDependencies],
     );
 
   const getQueriesToUpdate = (mutationData: Data) => {
@@ -169,6 +173,7 @@ export const createNormalizer = (
       normalizedData.objects,
       updatedObjects,
     );
+    console.log('normalizedDataWithMutation', updatedObjects);
 
     const foundQueries = getQueriesById(Object.keys(updatedObjects));
 

--- a/packages/normy/src/create-normalizer.ts
+++ b/packages/normy/src/create-normalizer.ts
@@ -173,7 +173,6 @@ export const createNormalizer = (
       normalizedData.objects,
       updatedObjects,
     );
-    console.log('normalizedDataWithMutation', updatedObjects);
 
     const foundQueries = getQueriesById(Object.keys(updatedObjects));
 

--- a/packages/normy/src/create-normalizer.ts
+++ b/packages/normy/src/create-normalizer.ts
@@ -1,12 +1,12 @@
-import { normalize } from './normalize';
-import { denormalize } from './denormalize';
-import { mergeData } from './merge-data';
-import { defaultConfig } from './default-config';
 import { addOrRemoveDependencies } from './add-or-remove-dependencies';
-import { getQueriesDependentOnMutation } from './get-queries-dependent-on-mutation';
+import { defaultConfig } from './default-config';
+import { denormalize } from './denormalize';
 import { getDependenciesDiff } from './get-dependencies-diff';
+import { getQueriesDependentOnMutation } from './get-queries-dependent-on-mutation';
+import { mergeData } from './merge-data';
+import { normalize } from './normalize';
+import { Data, DataObject, NormalizedData, NormalizerConfig } from './types';
 import { warning } from './warning';
-import { Data, NormalizerConfig, NormalizedData, DataObject } from './types';
 
 const initialData: NormalizedData = {
   queries: {},
@@ -151,6 +151,12 @@ export const createNormalizer = (
     return differentObjects;
   };
 
+  const getQueriesById = (mutationDependencies: ReadonlyArray<string>) =>
+    getQueriesDependentOnMutation(
+      normalizedData.dependentQueries,
+      mutationDependencies,
+    );
+
   const getQueriesToUpdate = (mutationData: Data) => {
     const [, normalizedObjectsData] = normalize(mutationData, config);
 
@@ -164,10 +170,7 @@ export const createNormalizer = (
       updatedObjects,
     );
 
-    const foundQueries = getQueriesDependentOnMutation(
-      normalizedData.dependentQueries,
-      Object.keys(updatedObjects),
-    );
+    const foundQueries = getQueriesById(Object.keys(updatedObjects));
 
     return foundQueries.map(queryKey => ({
       queryKey,
@@ -218,6 +221,7 @@ export const createNormalizer = (
       normalizedData = initialData;
       currentDataReferences = {};
     },
+    getQueriesById,
     setQuery,
     removeQuery,
     getQueriesToUpdate,


### PR DESCRIPTION
Core: 
- Refactored "foundQueries" into an exposed getQueriesById function

React-query:
- Created a cleanIds function to convert strings in ID form into "@@id" format
- Created getQueryKeysById which exposes getQueriesById and parses the result to be compatible with tanstack-query {queryKey: } filters.
- Created a invalidateQueriesById which is just an opinionated implementation of getQueryKeysById, should probably be used over refetchQueries() unless you know what your doing.

Questions:
- Is there a cleaner way to "manual normalize" the Ids (to remove cleanIds helper)? 
- I accept a string | string[] which feels intuitive but seems to break some of the convention of the other functions. It also feels natural to have this method a normalizable object, or even array of normalizable objects as the user will most likely have the data in object form and will just need to flatMap over the ids.

