### PR TITLE
Track queries that use initialData in react-query

### DIFF
--- a/packages/normy-react-query/src/create-query-normalizer.spec.ts
+++ b/packages/normy-react-query/src/create-query-normalizer.spec.ts
@@ -480,4 +480,45 @@ describe('createQueryNormalizer', () => {
       name: 'Name updated',
     });
   });
+
+  it('updates normalizedData after a successful query that loads data from initialData', async () => {
+    const client = new QueryClient();
+    const normalizer = createQueryNormalizer(client);
+    normalizer.subscribe();
+
+    await client.prefetchQuery({
+      queryKey: ['book'],
+      staleTime: 10_000,
+      queryFn: () =>
+        Promise.resolve({
+          id: '1',
+          name: 'Name',
+        }),
+      initialData: () => ({
+        id: '1',
+        name: 'Name',
+      }),
+    });
+
+    expect(normalizer.getNormalizedData()).toEqual({
+      queries: {
+        '["book"]': {
+          data: '@@1',
+          dependencies: ['@@1'],
+          usedKeys: {
+            '': ['id', 'name'],
+          },
+        },
+      },
+      dependentQueries: {
+        '@@1': ['["book"]'],
+      },
+      objects: {
+        '@@1': {
+          id: '1',
+          name: 'Name',
+        },
+      },
+    });
+  });
 });

--- a/packages/normy-react-query/src/create-query-normalizer.ts
+++ b/packages/normy-react-query/src/create-query-normalizer.ts
@@ -53,6 +53,15 @@ export const createQueryNormalizer = (
         if (event.type === 'removed') {
           normalizer.removeQuery(JSON.stringify(event.query.queryKey));
         } else if (
+          event.type === 'added' &&
+          event.query.state.data !== undefined &&
+          shouldBeNormalized(normalize, event.query.meta?.normalize)
+        ) {
+          normalizer.setQuery(
+            JSON.stringify(event.query.queryKey),
+            event.query.state.data as Data,
+          );
+        } else if (
           event.type === 'updated' &&
           event.action.type === 'success' &&
           event.action.data !== undefined &&


### PR DESCRIPTION
Normy doesn't track queries that are loaded from `initialData`.

According to React-Query docs, `initialData` is supposed to be treated like fresh data coming from the server. When the `initialData` is returned, the query cache doesn't fire a `type: 'updated'` event. Instead it fires a `type: 'added'` event with the data already populated in `event.query.state.data`.

This PR makes sure Normy tracks those queries by checking for the `type: 'added'` event as well.

This is tested against 83e4f53 since builds on master currently fail due to TypeScript errors regarding `getQueriesById`.