### PR TITLE
Fix getQueriesToUpdate when mutation has fewer array items than the cached data

### DIFF
--- a/packages/normy/src/create-normalizer.spec.ts
+++ b/packages/normy/src/create-normalizer.spec.ts
@@ -683,6 +683,29 @@ describe('createNormalizer', () => {
       ]);
     });
 
+    it('returns query if mutation array and query array are of different length', () => {
+      const normalizer = createNormalizer();
+      normalizer.setQuery('query', {
+        id: '1',
+        list: [1, 2],
+      });
+
+      expect(
+        normalizer.getQueriesToUpdate({
+          id: '1',
+          list: [1],
+        }),
+      ).toEqual([
+        {
+          queryKey: 'query',
+          data: {
+            id: '1',
+            list: [1],
+          },
+        },
+      ]);
+    });
+
     it('works with equal date objects', () => {
       const normalizer = createNormalizer();
 

--- a/packages/normy/src/create-normalizer.ts
+++ b/packages/normy/src/create-normalizer.ts
@@ -20,8 +20,8 @@ const isMutationObjectDifferent = (
   normalizedData: Data,
 ): boolean => {
   if (Array.isArray(mutationData) && Array.isArray(normalizedData)) {
-    if (mutationData.length === 0) {
-      return normalizedData.length !== 0;
+    if (mutationData.length !== normalizedData.length) {
+      return true;
     }
 
     return mutationData.some((v, i) =>


### PR DESCRIPTION
Fixes the following scenario:

```js
await client.prefetchQuery({
  queryKey: ['book'],
  queryFn: () =>
    Promise.resolve({
      id: 'book:1',
      comments: [
        {
          id: 'comment:1',
          name: 'Comment 1',
        },
        {
          id: 'comment:2',
          name: 'Comment 2',
        },
      ],
    }),
});

normalizer.setNormalizedData({
  id: 'book:1',
  comments: [
    {
      id: 'comment:1',
      name: 'Comment 1',
    },
  ],
});
```

Previously, the `['book']` query would not be updated, even though the arrays containing comments are different. That's because `normalizer.getQueriesToUpdate() -> filterMutationObjects() -> isMutationObjectDifferent()` only looped through the array from the mutation when checking for changes. If the cached array had more items, those would not be checked.

This fix checks the length of the mutation array and cached array. If the lengths are not equal, we're guaranteed that something has changed. If the lengths are equal, we'll continue to loop through the mutation array like before (since both arrays now are of the same length, all items will be properly checked). If there are no items in either array, `Array.some` always returns `false`.